### PR TITLE
Fix support for externally declared records

### DIFF
--- a/.azure/pipelines/nightly-main.yaml
+++ b/.azure/pipelines/nightly-main.yaml
@@ -29,7 +29,7 @@ extends:
       skipBuildTagsForGitHubPullRequests: true
     pool:
       name: $(pool_name)
-      image: orleans-build-image
+      image: $(pool_image)
       os: windows
     stages:
     - stage: build_test

--- a/.azure/pipelines/templates/build.yaml
+++ b/.azure/pipelines/templates/build.yaml
@@ -57,9 +57,11 @@ jobs:
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         esrp_signing: false
         microbuild_signing: true
+        publishVstsFeed: 'public/orleans-nightly'
       ${{ else }}:
         esrp_signing: true
         microbuild_signing: false
+        publishVstsFeed: 'orleans-public/orleans-nightly'
     ${{ else }}:
       esrp_signing: false
       microbuild_signing: false
@@ -76,7 +78,7 @@ jobs:
           packageParentPath: $(Pipeline.Workspace)
           packagesToPush: $(build.sourcesdirectory)/Artifacts/${{parameters.build_configuration}}/**/*.nupkg
           nuGetFeedType: internal
-          publishVstsFeed: 'orleans-public/orleans-nightly'
+          publishVstsFeed: $(publishVstsFeed)
           allowPackageConflicts: true
   steps:
   - ${{ if eq(variables.microbuild_signing, true) }}:

--- a/.azure/pipelines/templates/vars.yaml
+++ b/.azure/pipelines/templates/vars.yaml
@@ -4,6 +4,7 @@ variables:
   build_flags: ' /m /v:m'
   solution: 'Orleans.sln'
   codesign_runtime: '2.1.x'
+  GDN_SUPPRESS_FORKED_BUILD_WARNING: true # Avoid warning "Guardian is not supported for builds from forked GitHub repositories"
   # Auto-injection is not necessary because the tasks are explicitly included where they're enabled.
   Codeql.SkipTaskAutoInjection: true
   ${{ if eq(variables['System.TeamProject'], 'GitHub - PR Builds') }}:

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -46,15 +46,15 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageVersion Include="Azure.Data.Tables" Version="12.8.1" />
-    <PackageVersion Include="Azure.Core" Version="1.35.0" />
+    <PackageVersion Include="Azure.Core" Version="1.41.0" />
     <PackageVersion Include="Azure.Messaging.EventHubs" Version="5.9.3" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.18.0" />
     <PackageVersion Include="Azure.Storage.Queues" Version="12.16.0" />
     <!-- Aspire -->
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="8.0.1" />
-    <PackageVersion Include="Aspire.Hosting.Orleans" Version="8.0.1" />
-    <PackageVersion Include="Aspire.Hosting.Redis" Version="8.0.1" />
-    <PackageVersion Include="Aspire.StackExchange.Redis" Version="8.0.1" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="8.1.0" />
+    <PackageVersion Include="Aspire.Hosting.Orleans" Version="8.1.0" />
+    <PackageVersion Include="Aspire.Hosting.Redis" Version="8.1.0" />
+    <PackageVersion Include="Aspire.StackExchange.Redis" Version="8.1.0" />
     <!-- 3rd party packages -->
     <PackageVersion Include="Google.Cloud.PubSub.V1" Version="1.0.0-beta13" />
     <PackageVersion Include="AWSSDK.DynamoDBv2" Version="3.7.300.6" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -45,11 +45,11 @@
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageVersion Include="Azure.Data.Tables" Version="12.8.1" />
+    <PackageVersion Include="Azure.Data.Tables" Version="12.9.0" />
     <PackageVersion Include="Azure.Core" Version="1.41.0" />
     <PackageVersion Include="Azure.Messaging.EventHubs" Version="5.9.3" />
-    <PackageVersion Include="Azure.Storage.Blobs" Version="12.18.0" />
-    <PackageVersion Include="Azure.Storage.Queues" Version="12.16.0" />
+    <PackageVersion Include="Azure.Storage.Blobs" Version="12.21.1" />
+    <PackageVersion Include="Azure.Storage.Queues" Version="12.19.1" />
     <!-- Aspire -->
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="8.1.0" />
     <PackageVersion Include="Aspire.Hosting.Orleans" Version="8.1.0" />

--- a/Orleans.sln
+++ b/Orleans.sln
@@ -220,6 +220,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tester.Redis", "test\Extens
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Orleans.Serialization.Protobuf", "src\Serializers\Orleans.Serialization.Protobuf\Orleans.Serialization.Protobuf.csproj", "{A073C0EE-8732-42F9-A22E-D47034E25076}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestSerializerExternalModels", "test\Misc\TestSerializerExternalModels\TestSerializerExternalModels.csproj", "{F9674B6B-67FF-4779-9B0F-41385AB1CE9E}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Cassandra", "Cassandra", "{42C80201-3AC6-4C10-9809-3315A9FDD7A1}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Orleans.Clustering.Cassandra", "src\Cassandra\Orleans.Clustering.Cassandra\Orleans.Clustering.Cassandra.csproj", "{7A1A2ECE-DC4B-4DE7-AEF7-855C50895171}"
@@ -632,6 +634,10 @@ Global
 		{F50F81B6-E9B5-4143-B66B-A1AD913F6E9C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F50F81B6-E9B5-4143-B66B-A1AD913F6E9C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F50F81B6-E9B5-4143-B66B-A1AD913F6E9C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F9674B6B-67FF-4779-9B0F-41385AB1CE9E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F9674B6B-67FF-4779-9B0F-41385AB1CE9E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F9674B6B-67FF-4779-9B0F-41385AB1CE9E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F9674B6B-67FF-4779-9B0F-41385AB1CE9E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -748,6 +754,7 @@ Global
 		{84B44F1D-B7FE-40E3-82F0-730A55AC8613} = {316CDCC7-323F-4264-9FC9-667662BB1F80}
 		{B2D53D3C-E44A-4C9B-AAEE-28FB8C1BDF62} = {A6573187-FD0D-4DF7-91D1-03E07E470C0A}
 		{F50F81B6-E9B5-4143-B66B-A1AD913F6E9C} = {4CD3AA9E-D937-48CA-BB6C-158E12257D23}
+		{F9674B6B-67FF-4779-9B0F-41385AB1CE9E} = {70BCC54E-1618-4742-A079-07588065E361}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7BFB3429-B5BB-4DB1-95B4-67D77A864952}

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ On Linux and macOS, run `dotnet build` to build Orleans.
 
 The latest stable, production-quality release is located [here](https://github.com/dotnet/orleans/releases/latest).
 
-Nightly builds are published to [a NuGet feed](https://orleans.pkgs.visualstudio.com/orleans-public/_packaging/orleans-nightly/nuget/v3/index.json). These builds pass all functional tests, but are not thoroughly tested as the stable builds or pre-release builds published to NuGet.
+Nightly builds are published to [a NuGet feed](https://pkgs.dev.azure.com/dnceng/public/_packaging/orleans-nightly/nuget/v3/index.json). These builds pass all functional tests, but are not thoroughly tested as the stable builds or pre-release builds published to NuGet.
 
 <details>
 <summary>
@@ -189,7 +189,7 @@ To use nightly builds in your project, add the MyGet feed using either of the fo
 <ItemGroup>
   <RestoreSources>
     $(RestoreSources);
-    https://orleans.pkgs.visualstudio.com/orleans-public/_packaging/orleans-nightly/nuget/v3/index.json
+    https://pkgs.dev.azure.com/dnceng/public/_packaging/orleans-nightly/nuget/v3/index.json
   </RestoreSources>
 </ItemGroup>
 ```
@@ -203,7 +203,7 @@ or
 <configuration>
   <packageSources>
     <clear /> 
-    <add key="orleans-nightly" value="https://orleans.pkgs.visualstudio.com/orleans-public/_packaging/orleans-nightly/nuget/v3/index.json" />
+    <add key="orleans-nightly" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/orleans-nightly/nuget/v3/index.json" />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/Orleans.CodeGenerator/FieldIdAssignmentHelper.cs
+++ b/src/Orleans.CodeGenerator/FieldIdAssignmentHelper.cs
@@ -74,6 +74,18 @@ internal class FieldIdAssignmentHelper
                 {
                     _symbols[member] = (id.Value, false);
                 }
+                else if (PropertyUtility.GetMatchingPrimaryConstructorParameter(prop, _constructorParameters) is { } prm)
+                {
+                    id = CodeGenerator.GetId(_libraryTypes, prop);
+                    if (id.HasValue)
+                    {
+                        _symbols[member] = (id.Value, true);
+                    }
+                    else
+                    {
+                        _symbols[member] = ((uint)_constructorParameters.IndexOf(prm), true);
+                    }
+                }
             }
 
             if (member is IFieldSymbol field)

--- a/src/Orleans.CodeGenerator/Model/SerializableTypeDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/SerializableTypeDescription.cs
@@ -173,7 +173,7 @@ namespace Orleans.CodeGenerator
                     t = t.BaseType;
                 }
 
-                foreach (var ctor in Type.Constructors)
+                foreach (var ctor in Type.Constructors.Where(x => x.IsImplicitlyDeclared))
                 {
                     if (ctor.Parameters.Length != 0)
                     {

--- a/src/Orleans.CodeGenerator/Orleans.CodeGenerator.csproj
+++ b/src/Orleans.CodeGenerator/Orleans.CodeGenerator.csproj
@@ -10,6 +10,7 @@
     <DevelopmentDependency>true</DevelopmentDependency>
     <IsOrleansFrameworkPart>false</IsOrleansFrameworkPart>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <IsRoslynComponent>true</IsRoslynComponent>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Orleans.CodeGenerator/OrleansSourceGenerator.cs
+++ b/src/Orleans.CodeGenerator/OrleansSourceGenerator.cs
@@ -23,16 +23,17 @@ namespace Orleans.CodeGenerator
                     return;
                 }
 
-                if (context.AnalyzerConfigOptions.GlobalOptions.TryGetValue("build_property.orleans_designtimebuild", out var isDesignTimeBuild)
-                    && string.Equals("true", isDesignTimeBuild, StringComparison.OrdinalIgnoreCase))
-                {
-                    return;
-                }
-
                 if (context.AnalyzerConfigOptions.GlobalOptions.TryGetValue("build_property.orleans_attachdebugger", out var attachDebuggerOption)
                     && string.Equals("true", attachDebuggerOption, StringComparison.OrdinalIgnoreCase))
                 {
                     Debugger.Launch();
+                }
+
+                if (!Debugger.IsAttached &&
+                    context.AnalyzerConfigOptions.GlobalOptions.TryGetValue("build_property.orleans_designtimebuild", out var isDesignTimeBuild)
+                    && string.Equals("true", isDesignTimeBuild, StringComparison.OrdinalIgnoreCase))
+                {
+                    return;
                 }
 
                 var options = new CodeGeneratorOptions();

--- a/src/Orleans.CodeGenerator/Properties/launchSettings.json
+++ b/src/Orleans.CodeGenerator/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "Roslyn": {
+      "commandName": "DebugRoslynComponent",
+      "targetProject": "..\\..\\test\\Orleans.Serialization.UnitTests\\Orleans.Serialization.UnitTests.csproj"
+    }
+  }
+}

--- a/src/Orleans.CodeGenerator/PropertyUtility.cs
+++ b/src/Orleans.CodeGenerator/PropertyUtility.cs
@@ -18,6 +18,22 @@ namespace Orleans.CodeGenerator
             return GetMatchingProperty(field, field.ContainingType.GetMembers());
         }
 
+        public static bool IsCompilerGenerated(this ISymbol? symbol)
+            => symbol?.GetAttributes().Any(a => a.AttributeClass?.Name == "CompilerGeneratedAttribute") == true;
+
+        public static bool IsCompilerGenerated(this IPropertySymbol? property)
+            => property?.GetMethod.IsCompilerGenerated() == true && property.SetMethod.IsCompilerGenerated();
+
+        public static IParameterSymbol? GetMatchingPrimaryConstructorParameter(IPropertySymbol property, IEnumerable<IParameterSymbol> constructorParameters)
+        {
+            if (!property.IsCompilerGenerated())
+                return null;
+
+            return constructorParameters.FirstOrDefault(p =>
+                string.Equals(p.Name, property.Name, StringComparison.Ordinal) &&
+                SymbolEqualityComparer.Default.Equals(p.Type, property.Type));
+        }
+
         public static IPropertySymbol? GetMatchingProperty(IFieldSymbol field, IEnumerable<ISymbol> memberSymbols)
         {
             var propertyName = PropertyMatchRegex.Match(field.Name);

--- a/test/Grains/TestFSharp/Types.fs
+++ b/test/Grains/TestFSharp/Types.fs
@@ -1,6 +1,28 @@
 namespace UnitTests.FSharpTypes
 
+open System.Runtime.CompilerServices
 open Orleans
+
+[<Immutable; GenerateSerializer>]
+type EnumStyleDU =
+    | Case1
+    | Case2
+    | Case3
+
+[<Immutable; GenerateSerializer>]
+type MixCaseDU =
+    | Case1
+    | Case2 of string
+
+[<Immutable; GenerateSerializer>]
+type RecursiveDU =
+    | Case1
+    | Case2 of RecursiveDU
+
+[<Immutable; GenerateSerializer>]
+type GenericDU<'T> =
+    | Case1 of 'T
+    | Case2
 
 [<Immutable; GenerateSerializer>]
 type SingleCaseDU =
@@ -24,6 +46,14 @@ type QuadrupleCaseDU =
     | Case2 of int
     | Case3 of char
     | Case4 of byte
+
+[<Immutable; GenerateSerializer>]
+type QuintupleCaseDU =
+    | Case1
+    | Case2 of int
+    | Case3
+    | Case4 of byte
+    | Case5 of string
 
 [<Immutable; GenerateSerializer>]
 type Record = {  [<Id(1u)>] A: SingleCaseDU } with
@@ -60,8 +90,11 @@ type DiscriminatedUnion =
 
     static member set s = SetFieldCase s
     static member emptySet() = SetFieldCase Set.empty
-    static member nonEmptySet() = Set.ofList [1; 2; 3] |> SetFieldCase 
+    static member nonEmptySet() = Set.ofList [1; 2; 3] |> SetFieldCase
 
     static member map m = MapFieldCase m
     static member emptyMap() = MapFieldCase Map.empty
-    static member nonEmptyMap() = Map.ofList [0, "zero"; 1, "one"] |> MapFieldCase 
+    static member nonEmptyMap() = Map.ofList [0, "zero"; 1, "one"] |> MapFieldCase
+
+[<InternalsVisibleTo("TestFSharpGrainInterfaces")>]
+do ()

--- a/test/Misc/TestSerializerExternalModels/Models.cs
+++ b/test/Misc/TestSerializerExternalModels/Models.cs
@@ -3,7 +3,7 @@ using Orleans;
 namespace UnitTests.SerializerExternalModels;
 
 [GenerateSerializer]
-public record struct Person2External(int Age, string Name)
+public record struct Person2ExternalStruct(int Age, string Name)
 {
     [Id(0)]
     public string FavouriteColor { get; set; }
@@ -11,3 +11,15 @@ public record struct Person2External(int Age, string Name)
     [Id(1)]
     public string StarSign { get; set; }
 }
+
+#if NET6_0_OR_GREATER
+[GenerateSerializer]
+public record Person2External(int Age, string Name)
+{
+    [Id(0)]
+    public string FavouriteColor { get; set; }
+
+    [Id(1)]
+    public string StarSign { get; set; }
+}
+#endif

--- a/test/Misc/TestSerializerExternalModels/Models.cs
+++ b/test/Misc/TestSerializerExternalModels/Models.cs
@@ -1,0 +1,13 @@
+using Orleans;
+
+namespace UnitTests.SerializerExternalModels;
+
+[GenerateSerializer]
+public record struct Person2External(int Age, string Name)
+{
+    [Id(0)]
+    public string FavouriteColor { get; set; }
+
+    [Id(1)]
+    public string StarSign { get; set; }
+}

--- a/test/Misc/TestSerializerExternalModels/TestSerializerExternalModels.csproj
+++ b/test/Misc/TestSerializerExternalModels/TestSerializerExternalModels.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>UnitTests.SerializerExternalModels</RootNamespace>
+    <AssemblyName>SerializerExternalModels</AssemblyName>
+    <TargetFrameworks>$(TestTargetFrameworks);netcoreapp3.1</TargetFrameworks>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Orleans.Serialization.Abstractions\Orleans.Serialization.Abstractions.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/Orleans.Serialization.FSharp.Tests/SerializationTests.fs
+++ b/test/Orleans.Serialization.FSharp.Tests/SerializationTests.fs
@@ -20,6 +20,72 @@ type FSharpSerializationTests(fixture: DefaultClusterFixture) =
         Assert.Equal((), copy)
 
     [<Fact; TestCategory("BVT"); TestCategory("Serialization")>]
+    let Serialization_Roundtrip_FSharp_EnumStyleDU () =
+        let case1 = EnumStyleDU.Case1
+        let case2 = EnumStyleDU.Case2
+
+        let roundtrippedCase1 = cluster.RoundTripSerializationForTesting case1
+        let roundtrippedCase2 = cluster.RoundTripSerializationForTesting case2
+        let copyCase1 = cluster.DeepCopy case1
+        let copyCase2 = cluster.DeepCopy case2
+        Assert.Equal(case1, roundtrippedCase1)
+        Assert.Equal(case2, roundtrippedCase2)
+        Assert.Equal(case1, copyCase1)
+        Assert.Equal(case2, copyCase2)
+
+    [<Fact; TestCategory("BVT"); TestCategory("Serialization")>]
+    let Serialization_Roundtrip_FSharp_MixCaseDU () =
+        let case1 = MixCaseDU.Case1
+        let case2 = MixCaseDU.Case2 "Case2"
+
+        let roundtrippedCase1 = cluster.RoundTripSerializationForTesting case1
+        let roundtrippedCase2 = cluster.RoundTripSerializationForTesting case2
+        let copyCase1 = cluster.DeepCopy case1
+        let copyCase2 = cluster.DeepCopy case2
+        Assert.Equal(case1, roundtrippedCase1)
+        Assert.Equal(case2, roundtrippedCase2)
+        Assert.Equal(case1, copyCase1)
+        Assert.Equal(case2, copyCase2)
+
+    [<Fact; TestCategory("BVT"); TestCategory("Serialization")>]
+    let Serialization_Roundtrip_FSharp_RecursiveDU () =
+        let case1 = RecursiveDU.Case1
+        let case2 = RecursiveDU.Case2 (RecursiveDU.Case2 RecursiveDU.Case1)
+
+        let roundtrippedCase1 = cluster.RoundTripSerializationForTesting case1
+        let roundtrippedCase2 = cluster.RoundTripSerializationForTesting case2
+        let copyCase1 = cluster.DeepCopy case1
+        let copyCase2 = cluster.DeepCopy case2
+        Assert.Equal(case1, roundtrippedCase1)
+        Assert.Equal(case2, roundtrippedCase2)
+        Assert.Equal(case1, copyCase1)
+        Assert.Equal(case2, copyCase2)
+
+    [<Fact; TestCategory("BVT"); TestCategory("Serialization")>]
+    let Serialization_Roundtrip_FSharp_GenericDU () =
+        let case1String = GenericDU.Case1 "string"
+        let case1Int = GenericDU.Case1 99
+        let case1Case2 = GenericDU.Case1 GenericDU.Case2
+        let case2 = GenericDU.Case2
+
+        let roundtrippedCase1String = cluster.RoundTripSerializationForTesting case1String
+        let roundtrippedCase1Int = cluster.RoundTripSerializationForTesting case1Int
+        let roundtrippedCase1Case2 = cluster.RoundTripSerializationForTesting case1Case2
+        let roundtrippedCase2 = cluster.RoundTripSerializationForTesting case2
+        let copyCase1String = cluster.DeepCopy case1String
+        let copyCase1Int = cluster.DeepCopy case1Int
+        let copyCase1Case2 = cluster.DeepCopy case1Case2
+        let copyCase2 = cluster.DeepCopy case2
+        Assert.Equal(case1String, roundtrippedCase1String)
+        Assert.Equal(case1Int, roundtrippedCase1Int)
+        Assert.Equal(case1Case2, roundtrippedCase1Case2)
+        Assert.Equal(case2, roundtrippedCase2)
+        Assert.Equal(case1String, copyCase1String)
+        Assert.Equal(case1Int, copyCase1Int)
+        Assert.Equal(case1Case2, copyCase1Case2)
+        Assert.Equal(case2, copyCase2)
+
+    [<Fact; TestCategory("BVT"); TestCategory("Serialization")>]
     let Serialization_Roundtrip_FSharp_SingleCaseDiscriminatedUnion () =
         let du = SingleCaseDU.Case1 1
         let roundtripped = cluster.RoundTripSerializationForTesting du
@@ -62,7 +128,7 @@ type FSharpSerializationTests(fixture: DefaultClusterFixture) =
         Assert.Equal(case2, copyCase2)
         Assert.Equal(case3, copyCase3)
 
-    [<Fact(Skip = "DUs with 4 or more cases fail when trying to instantiate Case{2-4}-classes via RuntimeHelpers.GetUninitializedObject when deserializing")>]
+    [<Fact>]
     [<TestCategory("BVT"); TestCategory("Serialization")>]
     let Serialization_Roundtrip_FSharp_QuadrupleCaseDiscriminatedUnion () =
         let case1 = QuadrupleCaseDU.Case1 "case 1"
@@ -86,4 +152,35 @@ type FSharpSerializationTests(fixture: DefaultClusterFixture) =
         Assert.Equal(case1, copyCase1);
         Assert.Equal(case2, copyCase2);
         Assert.Equal(case3, copyCase3);
-        Assert.Equal(case4, copyCase4);
+        Assert.Equal(case4, copyCase4)
+
+    [<Fact>]
+    [<TestCategory("BVT"); TestCategory("Serialization")>]
+    let Serialization_Roundtrip_FSharp_QuintupleCaseDiscriminatedUnion () =
+        let case1 = QuintupleCaseDU.Case1
+        let case2 = QuintupleCaseDU.Case2 2
+        let case3 = QuintupleCaseDU.Case3
+        let case4 = QuintupleCaseDU.Case4 1uy
+        let case5 = QuintupleCaseDU.Case5 "case 5"
+
+        let roundtrippedCase1 = cluster.RoundTripSerializationForTesting case1
+        let roundtrippedCase2 = cluster.RoundTripSerializationForTesting case2
+        let roundtrippedCase3 = cluster.RoundTripSerializationForTesting case3
+        let roundtrippedCase4 = cluster.RoundTripSerializationForTesting case4
+        let roundtrippedCase5 = cluster.RoundTripSerializationForTesting case5
+        let copyCase1 = cluster.DeepCopy case1
+        let copyCase2 = cluster.DeepCopy case2
+        let copyCase3 = cluster.DeepCopy case3
+        let copyCase4 = cluster.DeepCopy case4
+        let copyCase5 = cluster.DeepCopy case5
+
+        Assert.Equal(case1, roundtrippedCase1);
+        Assert.Equal(case2, roundtrippedCase2);
+        Assert.Equal(case3, roundtrippedCase3);
+        Assert.Equal(case4, roundtrippedCase4);
+        Assert.Equal(case5, roundtrippedCase5);
+        Assert.Equal(case1, copyCase1);
+        Assert.Equal(case2, copyCase2);
+        Assert.Equal(case3, copyCase3);
+        Assert.Equal(case4, copyCase4)
+        Assert.Equal(case5, copyCase5)

--- a/test/Orleans.Serialization.UnitTests/GeneratedSerializerTests.cs
+++ b/test/Orleans.Serialization.UnitTests/GeneratedSerializerTests.cs
@@ -14,7 +14,10 @@ using System.Linq;
 using UnitTests.SerializerExternalModels;
 using Orleans;
 
+[assembly: GenerateCodeForDeclaringAssembly(typeof(Person2ExternalStruct))]
+#if NET6_0_OR_GREATER
 [assembly: GenerateCodeForDeclaringAssembly(typeof(Person2External))]
+#endif
 
 namespace Orleans.Serialization.UnitTests;
 
@@ -131,6 +134,25 @@ public class GeneratedSerializerTests : IDisposable
     }
 
     [Fact]
+    public void GeneratedLibExternalRecordStructWithPCtorSerializersRoundTripThroughCodec()
+    {
+        var original = new Person2ExternalStruct(2, "harry")
+        {
+            FavouriteColor = "redborine",
+            StarSign = "Aquaricorn"
+        };
+
+        var result = RoundTripThroughCodec(original);
+
+        Assert.Equal(original.Age, result.Age);
+        Assert.Equal(original.Name, result.Name);
+        Assert.Equal(original.FavouriteColor, result.FavouriteColor);
+        Assert.Equal(original.StarSign, result.StarSign);
+    }
+
+#if NET6_0_OR_GREATER
+
+    [Fact]
     public void GeneratedLibExternalRecordWithPCtorSerializersRoundTripThroughCodec()
     {
         var original = new Person2External(2, "harry")
@@ -146,6 +168,8 @@ public class GeneratedSerializerTests : IDisposable
         Assert.Equal(original.FavouriteColor, result.FavouriteColor);
         Assert.Equal(original.StarSign, result.StarSign);
     }
+
+#endif
 
 #if NET6_0_OR_GREATER
     [Fact]

--- a/test/Orleans.Serialization.UnitTests/GeneratedSerializerTests.cs
+++ b/test/Orleans.Serialization.UnitTests/GeneratedSerializerTests.cs
@@ -11,6 +11,10 @@ using System.Collections.Generic;
 using System.IO.Pipelines;
 using Xunit;
 using System.Linq;
+using UnitTests.SerializerExternalModels;
+using Orleans;
+
+[assembly: GenerateCodeForDeclaringAssembly(typeof(Person2External))]
 
 namespace Orleans.Serialization.UnitTests;
 
@@ -113,6 +117,23 @@ public class GeneratedSerializerTests : IDisposable
     public void GeneratedRecordWithPCtorSerializersRoundTripThroughCodec()
     {
         var original = new Person2(2, "harry")
+        {
+            FavouriteColor = "redborine",
+            StarSign = "Aquaricorn"
+        };
+
+        var result = RoundTripThroughCodec(original);
+
+        Assert.Equal(original.Age, result.Age);
+        Assert.Equal(original.Name, result.Name);
+        Assert.Equal(original.FavouriteColor, result.FavouriteColor);
+        Assert.Equal(original.StarSign, result.StarSign);
+    }
+
+    [Fact]
+    public void GeneratedLibExternalRecordWithPCtorSerializersRoundTripThroughCodec()
+    {
+        var original = new Person2External(2, "harry")
         {
             FavouriteColor = "redborine",
             StarSign = "Aquaricorn"

--- a/test/Orleans.Serialization.UnitTests/Orleans.Serialization.UnitTests.csproj
+++ b/test/Orleans.Serialization.UnitTests/Orleans.Serialization.UnitTests.csproj
@@ -7,6 +7,7 @@
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
     <ImplicitUsings>disable</ImplicitUsings>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
   </PropertyGroup>
 
   <ItemGroup>
@@ -29,6 +30,7 @@
     <ProjectReference Include="$(SourceRoot)src\Orleans.Serialization.NewtonsoftJson\Orleans.Serialization.NewtonsoftJson.csproj" />
     <ProjectReference Include="$(SourceRoot)src\Orleans.Serialization.MessagePack\Orleans.Serialization.MessagePack.csproj" />
     <ProjectReference Include="$(SourceRoot)src\Serializers\Orleans.Serialization.Protobuf\Orleans.Serialization.Protobuf.csproj" />
+    <ProjectReference Include="..\Misc\TestSerializerExternalModels\TestSerializerExternalModels.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes improper codec codegen for records declared in referenced projects/assemblies. Roslyn does not guarantee the symbols contain the backing fields for generated properties (see https://github.com/dotnet/roslyn/discussions/72374#discussioncomment-8655916) and it also doesn't even report `record struct` symbols as records at all (see https://github.com/dotnet/roslyn/issues/69326).

This makes for a very inconsistent experience when dealing with types defined in external assemblies that don't use the Orleans SDK themselves.

We implement a heuristics here to determine primary constructors that can be relied upon to detect them consistently:
1. A ctor with non-zero parameters
2. All parameters match by name exactly with corresponding properties
3. All matching properties have getter AND setter annotated with [CompilerGenerated].

In addition, since the backing field isn't available at all in these records, and the corresponding property isn't settable (it's generated as `init set`), we leverage unsafe accessors (see https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.unsafeaccessorattribute?view=net-8.0) instead. The code checks whether the `FieldAccessorDescription` has an initializer syntax or not to determine whether to generate the original code or the new accessor version.

The signature of the accessor matches the delegate that is generated for the regular backing field case, so there is no need to modify other call sites.

Fixes #9092